### PR TITLE
feat: migrate commits from Flatline Server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
         <semver4j.version>3.1.0</semver4j.version>
         <snakeyaml.version>2.4</snakeyaml.version>
         <syslog4j.version>0.9.30</syslog4j.version>
+        <!-- FLT(uoemai): Default to storing container image locally. Use "build" to push to a registry. -->
+        <jib.goal>dockerBuild</jib.goal>
 
         <!-- test -->
         <assertj-core.version>3.27.3</assertj-core.version>
@@ -365,7 +367,8 @@
                             <execution>
                                 <phase>package</phase>
                                 <goals>
-                                    <goal>build</goal>
+                                    <!-- FLT(uoemai): Allow customizing container image storage. -->
+                                    <goal>${jib.goal}</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -397,6 +400,8 @@
                                 <ports>
                                     <port>8080</port>
                                 </ports>
+                                <!-- FLT(uoemai): Timestamp container image. -->
+                                <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                             </container>
                             <extraDirectories>
                                 <paths>

--- a/src/main/java/org/signal/storageservice/StorageService.java
+++ b/src/main/java/org/signal/storageservice/StorageService.java
@@ -58,7 +58,8 @@ public class StorageService extends Application<StorageServiceConfiguration> {
 
   @Override
   public void run(StorageServiceConfiguration config, Environment environment) throws Exception {
-    MetricsUtil.configureRegistries(config, environment);
+    // FLT(uoemai): Remove dependency on Datadog SaaS during development.
+    // MetricsUtil.configureRegistries(config, environment);
 
     UncaughtExceptionHandler.register();
 
@@ -108,9 +109,9 @@ public class StorageService extends Application<StorageServiceConfiguration> {
     environment.jersey().register(new GroupsController(Clock.systemUTC(), groupsManager, serverSecretParams, policySigner, postPolicyGenerator, config.getGroupConfiguration(), externalGroupCredentialGenerator));
     environment.jersey().register(new GroupsV1Controller(Clock.systemUTC(), groupsManager, serverSecretParams, policySigner, postPolicyGenerator, config.getGroupConfiguration(), externalGroupCredentialGenerator));
 
-    new MetricsHttpChannelListener().configure(environment);
-
-    MetricsUtil.registerSystemResourceMetrics(environment);
+    // FLT(uoemai): Remove dependency on Datadog SaaS during development.
+    // new MetricsHttpChannelListener().configure(environment);
+    // MetricsUtil.registerSystemResourceMetrics(environment);
   }
 
   public static void main(String[] argv) throws Exception {


### PR DESCRIPTION
This PR migrates the relevant commits from the Flatline Server monorepo to this repository.

The following PRs have been migrated:
https://github.com/mollyim/flatline-server/pull/20
https://github.com/mollyim/flatline-server/pull/23

The following commit has been intentionally excluded:
https://github.com/mollyim/flatline-server/commit/922d1b44b120f8bcffd7dc755f7a7714dc8309a8

All changes related to Maven have been migrated as well.